### PR TITLE
Add workflow for multi-arch-build, and prerequisites.

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+tag=2.89.6
+alpine_tag=3.19
+dnsmasq_version=2.89-r6
+platforms=linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8

--- a/.github/workflows/multi-arch-build.yml
+++ b/.github/workflows/multi-arch-build.yml
@@ -1,0 +1,89 @@
+name: "Multi-arch docker build"
+
+# Controls when the workflow will run
+on:
+  push:
+    branches: ['main']
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches: ['main']
+
+env:
+  TEST_TAG: ministryofjustice/dory-dnsmasq:test
+  ALPINE_TAG: 3.19
+  DNSMASQ_VERSION: 2.89-r6
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # First, checkout
+      - name: Checkout
+        uses: actions/checkout@v3.1.0
+
+      # QEMU; multi-arch stuff
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+
+      # get buildx - build multi-arch stuff
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2.3.0
+
+      # Access Docker Hub
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Setup test build for PRs
+      - name: Test - build and export to Docker
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          load: true
+          tags: ${{ env.TEST_TAG }}
+        build-args:
+          alpine_tag: ALPINE_TAG
+          dnsmasq_version: DNSMASQ_VERSION
+
+      # Gather meta for the builds
+      - name: Docker meta
+        if: github.event_name != 'pull_request'
+        id: dory-dnsmasq-meta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          images: ministryofjustice/dory-dnsmasq
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+          flavor: |
+            latest=true
+          build-args:
+            alpine_tag: ALPINE_TAG
+            dnsmasq_version: DNSMASQ_VERSION
+
+      # perform the builds
+      - name: Build and push
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: |
+            linux/amd64
+            linux/arm/v7
+            linux/arm/v8
+            linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.dory-dnsmasq-meta.outputs.tags }}
+          labels: ${{ steps.dory-dnsmasq-meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM andyshinn/dnsmasq:2.75
+ARG alpine_tag
+
+FROM alpine:${alpine_tag}
+
+ARG dnsmasq_version
+RUN apk --no-cache add dnsmasq-dnssec=${dnsmasq_version}
+EXPOSE 53 53/udp
 
 COPY dnsmasq.conf /etc/dnsmasq.conf
 COPY start-with-domain-ip.sh /usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+include .env
+
+default: help
+
+## help		:	Prints this help.
+.PHONY: help
+help :
+	@sed -n 's/^##//p' Makefile
+
+## builder	:	Create the builder.
+.PHONY: builder
+builder :
+	docker buildx create --name dory --use
+
+## build push	:	Build and push docker images.
+.PHONY: build push
+build push :
+	docker buildx build --build-arg alpine_tag=${alpine_tag} --build-arg dnsmasq_version=${dnsmasq_version} --platform ${platforms} -t docker.io/tripox/dory-dnsmasq:${tag} . --push
+	docker buildx build --build-arg alpine_tag=${alpine_tag} --build-arg dnsmasq_version=${dnsmasq_version} --platform ${platforms} -t docker.io/tripox/dory-dnsmasq:latest . --push
+
+## remove		:	Remove the builder.
+.PHONY: remove
+remove :
+	docker buildx rm dory

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [Dory](https://github.com/FreedomBen/dory) uses this container to provide the dnsmasq
 services in conjunction with an nginx-proxy.  It's a very lightweight container built
-on Alpine Linux (based off of [andyshinn/dnsmasq](https://hub.docker.com/r/andyshinn/dnsmasq/).
+on Alpine Linux, using only the dnsmasq-dnssec package.
 See the [dory](https://github.com/FreedomBen/dory) project page for more info.
 
 ## How do I use it?
@@ -62,3 +62,28 @@ docker run -p 53:53/tcp -p 53:53/udp --cap-add=NET_ADMIN freedomben/dory-dnsmasq
 ```
 
 *NOTE:  You have to put the # in quotes otherwise bash will think it's a comment character*
+
+### Build and push images
+
+Create the builder:
+
+```bash
+make builder
+```
+
+Build and push images:
+
+```bash
+make build push
+```
+
+Remove the builder:
+
+```bash
+make remove
+```
+
+### Credit
+
+- A lightweight docker image for dnsmasq [andyshinn/dnsmasq](https://hub.docker.com/r/andyshinn/dnsmasq/).
+- A PR to add compatibility for Mac M-series chips [tripox/dory-dnsmasq](https://github.com/tripox/dory-dnsmasq/commit/72549c39324014c5092cb8103378d58fbf51df80).

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ make remove
 ### Releases
 
 A GitHub workflow is used to build and push a container image to Docker Hub.
-- Before release, ensure that you have ound a valid version of dnsmasq-dnssec, on the [Alpine Packages page](https://pkgs.alpinelinux.org/packages?name=dnsmasq-dnssec&branch=v3.19&repo=&arch=&maintainer=).
+- Before release, ensure that you have found a valid version of dnsmasq-dnssec, on the [Alpine Packages page](https://pkgs.alpinelinux.org/packages?name=dnsmasq-dnssec&branch=v3.19&repo=&arch=&maintainer=).
 - Ensure that this version number is assigned to `DNSMASQ_VERSION` in [.github/workflows/multi-arch-build.yml]. e.g. `DNSMASQ_VERSION=2.89-r6`.
 - Create a PR into main branch.
 - After an accepted PR, tag the commit with a version in the format of `v2.89.6` to build and push the image.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ docker run -p 53:53/tcp -p 53:53/udp --cap-add=NET_ADMIN freedomben/dory-dnsmasq
 
 ### Build and push images
 
+The following commands are useful for local development.
+
 Create the builder:
 
 ```bash
@@ -82,6 +84,14 @@ Remove the builder:
 ```bash
 make remove
 ```
+
+### Releases
+
+A GitHub workflow is used to build and push a container image to Docker Hub.
+- Before release, ensure that you have ound a valid version of dnsmasq-dnssec, on the [Alpine Packages page](https://pkgs.alpinelinux.org/packages?name=dnsmasq-dnssec&branch=v3.19&repo=&arch=&maintainer=).
+- Ensure that this version number is assigned to `DNSMASQ_VERSION` in [.github/workflows/multi-arch-build.yml]. e.g. `DNSMASQ_VERSION=2.89-r6`.
+- Create a PR into main branch.
+- After an accepted PR, tag the commit with a version in the format of `v2.89.6` to build and push the image.
 
 ### Credit
 


### PR DESCRIPTION
This PR includes the work done here https://github.com/FreedomBen/dory-dnsmasq/pull/2 - it includes Mac M-series support and a makerfile (namely for local development).

It also uses the lates alpine release, and installs dnsmasq-dnssec within the Dockerfile, to reduce the external and outdated dependency on andyshinn/dnsmasq.

A workflow will build for multi-arch platforms and push to Docker Hub.