### PR TITLE
Update multi-arch-build.yml

### DIFF
--- a/.github/workflows/multi-arch-build.yml
+++ b/.github/workflows/multi-arch-build.yml
@@ -24,21 +24,21 @@ jobs:
     steps:
       # First, checkout
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.1.1
 
       # QEMU; multi-arch stuff
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.1.0
+        uses: docker/setup-qemu-action@v3.0.0
 
       # get buildx - build multi-arch stuff
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2.3.0
+        uses: docker/setup-buildx-action@v3.0.0
 
       # Access Docker Hub
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v3.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -46,7 +46,7 @@ jobs:
       # Setup test build for PRs
       - name: Test - build and export to Docker
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5.1.0
         with:
           context: .
           load: true
@@ -59,7 +59,7 @@ jobs:
       - name: Docker meta
         if: github.event_name != 'pull_request'
         id: dory-dnsmasq-meta
-        uses: docker/metadata-action@v4.3.0
+        uses: docker/metadata-action@v5.5.0
         with:
           images: ministryofjustice/dory-dnsmasq
           tags: |
@@ -73,7 +73,7 @@ jobs:
       # perform the builds
       - name: Build and push
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5.1.0
         with:
           context: .
           platforms: |


### PR DESCRIPTION
Version bump the actions to the latest. Addresses the warning: "Node.js 16 actions are deprecated as seen in the [action logs](https://github.com/ministryofjustice/dory-dnsmasq/actions/runs/7708800048).